### PR TITLE
Add realtime update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Stock-With-Lineer-Regression
+# Stock Price Predictor
+
+This project demonstrates training a simple model on S&P 500 data and updating predictions with daily market data. The included scripts allow you to fetch recent prices, retrain the model, and serve the latest prediction through a small web application.
+
+## Setup
+
+1. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Fetch the latest data and train the model:
+
+```bash
+python update_data.py
+python train_model.py
+```
+
+3. Start the web server:
+
+```bash
+python app.py
+```
+
+The server schedules a daily task at 17:00 UTC to download the most recent closing price for `AAPL` and update the prediction shown on the main page.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, render_template_string
+from apscheduler.schedulers.background import BackgroundScheduler
+import pandas as pd
+import joblib
+from pathlib import Path
+from datetime import datetime
+import update_data
+
+MODEL_FILE = Path('model.pkl')
+DATA_FILE = Path('recent_data.csv')
+
+app = Flask(__name__)
+
+latest_close = None
+latest_pred = None
+
+@app.route('/')
+def index():
+    global latest_close, latest_pred
+    if latest_close is None or latest_pred is None:
+        status = 'No data yet.'
+    else:
+        status = f'Latest close: {latest_close:.2f}, Predicted next close: {latest_pred:.2f}'
+    return render_template_string('<h1>Stock Predictor</h1><p>{{status}}</p>', status=status)
+
+def update():
+    global latest_close, latest_pred
+    update_data.main() if hasattr(update_data, 'main') else None
+    if DATA_FILE.exists() and MODEL_FILE.exists():
+        df = pd.read_csv(DATA_FILE)
+        df['date'] = pd.to_datetime(df['date'])
+        last_row = df.sort_values('date').iloc[-1]
+        latest_close = last_row['close']
+        model = joblib.load(MODEL_FILE)
+        feature_cols = ['open', 'high', 'low', 'close', 'volume']
+        X_new = last_row[feature_cols].values.reshape(1, -1)
+        latest_pred = model.predict(X_new)[0]
+        print(f'Updated prediction at {datetime.utcnow()}')
+
+scheduler = BackgroundScheduler()
+scheduler.add_job(update, 'cron', hour=17, minute=0)
+scheduler.start()
+
+# initial update on startup
+update()
+
+if __name__ == '__main__':
+    app.run(debug=False, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+flask
+pandas
+numpy
+scikit-learn
+yfinance
+apscheduler
+joblib

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+import joblib
+from pathlib import Path
+
+DATA_FILE = Path('SP 500 Stock Prices 2014-2017.csv')
+NEW_DATA_FILE = Path('recent_data.csv')
+MODEL_FILE = Path('model.pkl')
+
+hist_df = pd.read_csv(DATA_FILE)
+
+if NEW_DATA_FILE.exists():
+    new_df = pd.read_csv(NEW_DATA_FILE)
+    hist_df = pd.concat([hist_df, new_df], ignore_index=True)
+
+hist_df['date'] = pd.to_datetime(hist_df['date'])
+hist_df = hist_df.sort_values(['symbol', 'date'])
+hist_df['close_tomorrow'] = hist_df.groupby('symbol')['close'].shift(-1)
+hist_df = hist_df.dropna(subset=['close_tomorrow'])
+
+feature_cols = ['open', 'high', 'low', 'close', 'volume']
+X = hist_df[feature_cols]
+y = hist_df['close_tomorrow']
+
+# Replace any remaining NaN values
+X = X.fillna(method='ffill').fillna(method='bfill')
+
+model = LinearRegression()
+model.fit(X, y)
+
+joblib.dump(model, MODEL_FILE)
+print('Model trained and saved to', MODEL_FILE)

--- a/update_data.py
+++ b/update_data.py
@@ -1,0 +1,41 @@
+import yfinance as yf
+import pandas as pd
+from pathlib import Path
+from datetime import datetime, timedelta
+
+SYMBOL = 'AAPL'
+DATA_FILE = Path('recent_data.csv')
+
+def fetch():
+    if DATA_FILE.exists():
+        existing = pd.read_csv(DATA_FILE)
+        if not existing.empty:
+            last_date = pd.to_datetime(existing['date']).max()
+        else:
+            last_date = datetime.utcnow() - timedelta(days=30)
+    else:
+        existing = pd.DataFrame()
+        last_date = datetime.utcnow() - timedelta(days=30)
+
+    start = last_date + timedelta(days=1)
+    end = datetime.utcnow()
+
+    if start > end:
+        print('No new data to fetch')
+        return existing
+
+    df = yf.download(SYMBOL, start=start.strftime('%Y-%m-%d'), end=end.strftime('%Y-%m-%d'))
+    df = df.reset_index()[['Date', 'Open', 'High', 'Low', 'Close', 'Volume']]
+    df.columns = ['date', 'open', 'high', 'low', 'close', 'volume']
+    df['symbol'] = SYMBOL
+    new_data = df[['symbol', 'date', 'open', 'high', 'low', 'close', 'volume']]
+    all_data = pd.concat([existing, new_data], ignore_index=True)
+    all_data.to_csv(DATA_FILE, index=False)
+    print('Fetched and saved', len(new_data), 'rows')
+    return all_data
+
+def main():
+    fetch()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- build simple training script `train_model.py`
- add `update_data.py` to pull recent prices via `yfinance`
- create Flask app with scheduled updates
- document usage in README
- define runtime dependencies

## Testing
- `python update_data.py`
- `python train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_683f53d4dac8832ba8b0ad88aecf39bb